### PR TITLE
Hot Patch:  fixed execution of live-migration role

### DIFF
--- a/group_vars/hypervisors.yml
+++ b/group_vars/hypervisors.yml
@@ -1,7 +1,7 @@
 ---
 # Global Variables for 'hypervisors' Inventory Group
 
-live_migration: "True"
+live_migration: True
 nested_virt: "False"
 kernel_same_page_merging: "False"
 dhcp: "off"


### PR DESCRIPTION
live_migration was defined as a String in group_vars/hypervisors.yaml, but the when clause in pf9-express.yaml tested for a Boolean value.  So redefined live_migration to be a Boolean value.