### PR TITLE
updated qemu-kvm-ev role to work on RHEL

### DIFF
--- a/roles/qemu-kvm-ev/tasks/main.yml
+++ b/roles/qemu-kvm-ev/tasks/main.yml
@@ -1,18 +1,32 @@
 ---
-- name: ensure contentdir is configured in yum vars
-  copy:
-    dest: /etc/yum/vars/contentdir
-    content: 'centos'
-  when: ansible_os_family == "RedHat"
+# CentOS
+- block:
+  - name: ensure contentdir is configured in yum vars
+    copy:
+      dest: /etc/yum/vars/contentdir
+      content: 'centos'
 
-- name: install the centos-release-qemu-ev repo
-  yum:
-    name: centos-release-qemu-ev
-    state: latest
-  when: ansible_os_family == "RedHat"
+  - name: install the centos-release-qemu-ev repo
+    yum:
+      name: centos-release-qemu-ev
+      state: latest
 
-- name: install the latest version of qemu-kvm-ev
-  yum:
-    name: qemu-kvm-ev
-    state: latest
-  when: ansible_os_family == "RedHat"
+  - name: install the latest version of qemu-kvm-ev
+    yum:
+      name: qemu-kvm-ev
+      state: latest
+  when: ansible_distribution == "CentOS"
+
+# RedHat
+- block:
+  - name: install qemu packages
+    yum:
+      name: "{{item}}"
+      state: latest
+    with_items:
+      - qemu-kvm
+      - qemu-kvm-common
+      - qemu-kvm-tools
+      - qemu-guest-agent
+      - libvirt-daemon-driver-qemu
+  when: ansible_distribution == "RedHat"


### PR DESCRIPTION
Added RHEL support to qemu-kvm-ev role to install correct Qemu packages based on OS (Centos v RHEL)

Validate on two RHEL 7.4 hypervisors