### PR TITLE
Adding a simple dockerfile for the pf9-express

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,13 @@ USER root
 
 RUN yum -y install sudo
 
+RUN sed -i 's/#   StrictHostKeyChecking ask/StrictHostKeyChecking no/' /etc/ssh/ssh_config
+RUN echo 'UserKnownHostsFile /dev/null' >> /etc/ssh/ssh_config
+RUN echo 'IdentityFile /pf9/ansible-key' >> /etc/ssh/ssh_config
+
 WORKDIR  /opt
 RUN mkdir -p  /opt/pf9/express
 ADD ./ /opt/pf9/express
 RUN /opt/pf9/express/pf9-express -i
 
-ENTRYPOINT /opt/pf9/express/pf9-express 
+ENTRYPOINT ["/opt/pf9/express/pf9-express"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM centos/python-27-centos7
+USER root
+
+RUN yum -y install sudo
+
+WORKDIR  /opt
+RUN mkdir -p  /opt/pf9/express
+ADD ./ /opt/pf9/express
+RUN /opt/pf9/express/pf9-express -i
+
+ENTRYPOINT /opt/pf9/express/pf9-express 


### PR DESCRIPTION
A simple Dockerfile that encapsulates the pf9-express functionality. I haven't done any testing except running it. I will also push this to Dockerhub once I do some testing.