### PR TITLE
update entrypoint, and modify ssh_config to allow ansible functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,13 @@ USER root
 
 RUN yum -y install sudo
 
+RUN sed -i 's/#   StrictHostKeyChecking ask/StrictHostKeyChecking no/' /etc/ssh/ssh_config
+RUN echo 'UserKnownHostsFile /dev/null' >> /etc/ssh/ssh_config
+RUN echo 'IdentityFile /pf9/ansible-key' >> /etc/ssh/ssh_config
+
 WORKDIR  /opt
 RUN mkdir -p  /opt/pf9/express
 ADD ./ /opt/pf9/express
 RUN /opt/pf9/express/pf9-express -i
 
-ENTRYPOINT /opt/pf9/express/pf9-express 
+ENTRYPOINT ["/opt/pf9/express/pf9-express"]


### PR DESCRIPTION
Modified the entrypoint command to allow direct running of pf9-express by simply passing options and arguments to docker run.

Modified ssh_config to turn off strict host key checking for the container to enable ansible usage.