### PR TITLE
replace bond-config with bond_config to meet ansible dictates

### DIFF
--- a/pf9-express.yml
+++ b/pf9-express.yml
@@ -79,7 +79,7 @@
     - pre-hook
 
 # Configure the bond
-- hosts: bond-config
+- hosts: bond_config
   become: true
   roles:
     - { role: "bond-config", when: manage_network == True }


### PR DESCRIPTION
we missed updating the host group in pf9-express.yml so bonding gets skipped currently