### PR TITLE
Image URLs have been updated (302 not followed)

### DIFF
--- a/group_vars/glance.yml
+++ b/group_vars/glance.yml
@@ -5,6 +5,6 @@ glance_filesystem_store_datadir: /var/opt/pf9/imagelibrary/data
 glance_public_endpoint: False
 glance_images:
   - https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
-  - https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.img
-  #- https://cloud-images.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img
+  - https://cloud-images.ubuntu.com/releases/bionic/release/ubuntu-18.04-server-cloudimg-amd64.img
+  #- https://cloud-images.ubuntu.com/releases/xenial/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img
   - http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img


### PR DESCRIPTION
This patch fixes an issue resulting from the upstream image URLs being changed and the image(s) not being downloaded. Ansible is not following the 302s from the server. There is an undocumented 'follow' argument for get_url that might be of interest later.