### PR TITLE
Add a new ansible playbook for PMK only

### DIFF
--- a/pf9-express
+++ b/pf9-express
@@ -13,6 +13,7 @@ inventory=${basedir}/inventory/hosts
 express_script=${basedir}/pf9-express.yml
 deauth_script=${basedir}/pf9-deauth.yml
 k8s_upgrade_script=${basedir}/pf9-k8s-upgrade.yml
+k8s_only_playbook=${basedir}/pf9-k8s-express.yml
 platform=""
 target=""
 log=/tmp/pf9-express.log
@@ -36,6 +37,7 @@ flag_autoregister=0
 flag_csvImport=0
 flag_deauth=0
 flag_k8s_upgrade=0
+flag_pmk_only=0
 extra_vars=""
 awx_pf9_user="pf9"
 awx_pf9_password="Pl@tform9"
@@ -503,6 +505,9 @@ while [ $# -gt 0 ]; do
   -u|--upgradeK8s)
     flag_k8s_upgrade=1
     ;;
+  --pmk)
+    flag_pmk_only=1
+    ;;
   -f|--csvFile)
     if [ $# -lt 2 ]; then usage; fi
     flag_csvImport=1
@@ -671,6 +676,17 @@ if [ ${flag_deauth} -eq 1 ]; then
     sudo ansible-playbook -i ${inventory} -l ${target} -e "skip_prereq=${flag_skip_prereqs} autoreg=${autoreg} du_fqdn=${ctrl_hostname} ctrl_ip=${ctrl_ip} du_username=${du_username} du_password=${du_password} ${extra_vars}" ${deauth_script} 2>&1 | tee ${install_log}
     echo -e "Log: ${install_log}\n"
   fi
+  exit 0
+fi
+
+## Do stuff for PMK only
+if [ ${flag_pmk_only} -eq 1 ]; then
+  # Fail if ansible errors out.
+  set -euo pipefail
+  extra_vars="${extra_vars} k8s_only=1"
+  echo -e "Log: ${install_log}\n"
+  sudo ansible-playbook -i ${inventory} -l ${target} -e "skip_prereq=${flag_skip_prereqs} autoreg=${autoreg} du_fqdn=${ctrl_hostname} ctrl_ip=${ctrl_ip} du_username=${du_username} du_password=${du_password} ${extra_vars}" ${k8s_only_playbook} 2>&1 | tee ${install_log}
+  echo -e "Log: ${install_log}\n"
   exit 0
 fi
 

--- a/pf9-k8s-express.yml
+++ b/pf9-k8s-express.yml
@@ -1,0 +1,51 @@
+---
+##
+## pf9-express - Platform9 Systems, Inc. - https://www.platform9.com/
+##
+## This playbook can be used to deploy and manage Platform9's PMK product.
+##
+
+# Pre-tasks
+- hosts:
+    - k8s_master
+    - k8s_worker
+  become: true
+  gather_facts: False
+  pre_tasks:
+    - debug: var=autoreg
+    - name: install python2 on Ubuntu to enable running Ansible on Ubuntu hosts
+      raw: if [ -e /etc/lsb-release -a ! -e /usr/bin/python ]; then (apt-get -y update && apt-get install -y python-minimal); fi
+
+# Run pre_flight_checks
+- hosts:
+    - k8s_master
+    - k8s_worker
+  become: true
+  roles:
+    - pf9-auth
+
+# Kubernetes Master Nodes
+- hosts: k8s_master
+  become: true
+  roles:
+    - common
+    - ntp
+    - disable-swap
+    - pf9-hostagent
+    - { role: "wait-for-convergence", flags: "k8s", when: autoreg == "on" }
+    - { role: "map-role", rolename: "pf9-kube", when: autoreg == "on" }
+    - { role: "wait-for-convergence", when: autoreg == "on" }
+    - { role: "k8s-cluster-attach", k8s_node_type: "master", when: autoreg == "on" }
+
+# Kubernetes Worker Nodes
+- hosts: k8s_worker
+  become: true
+  roles:
+    - common
+    - ntp
+    - disable-swap
+    - pf9-hostagent
+    - { role: "wait-for-convergence", flags: "k8s", when: autoreg == "on" }
+    - { role: "map-role", rolename: "pf9-kube", when: autoreg == "on" }
+    - { role: "wait-for-convergence", when: autoreg == "on" }
+    - { role: "k8s-cluster-attach", k8s_node_type: "worker", when: autoreg == "on" }


### PR DESCRIPTION
This change breaks out the PMK specific steps into its own playbook. Note that the original pf9-express.yml playbook remains unchanged. This skips over all the non PMK tasks that are part of the main playbook. The new playbook has been completely inspired by the original playbook (mainly removed all the unnecessary roles/tasks)

Also, a new command option `--pmk` is added to the pf9-express bash script to allow invoking this new ansible playbook. Another tweak to this command is that it will fail immediately when the ansible step fails to return a non-zero exit code (unlike the behavior of other commands)

