### PR TITLE
Move failed jinja2 filter to a test

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: Quitting if hardware virtualization is not enabled
   fail:
     msg: "Hardware virtualization is not present, or not enabled."
-  when: hw_virt|failed and
+  when: hw_virt is failed and
         inventory_hostname in groups.hypervisors
 
 - block:

--- a/roles/pf9-hostagent/tasks/certless-hostinstaller-setup.yml
+++ b/roles/pf9-hostagent/tasks/certless-hostinstaller-setup.yml
@@ -4,6 +4,7 @@
   get_url:
     url: "https://{{du_fqdn}}/clarity/platform9-install-{{ansible_os_family|lower}}.sh"
     dest: "/tmp/platform9-install-{{ansible_os_family|lower}}.sh"
+    mode: 0755
     use_proxy: "{{ 'yes' if proxy_url is defined else 'no' }}"
 
 - include: certless-packages.yml

--- a/roles/pf9-hostagent/tasks/main.yml
+++ b/roles/pf9-hostagent/tasks/main.yml
@@ -13,14 +13,6 @@
     is_certless_installer: "true"
   when: result.status == 200
 
-- name: Display Variable
-  debug: msg="{{ result }}"
-  ignore_errors: yes
-
-- name: Display Variable
-  debug: msg="{{ is_certless_installer }}"
-  ignore_errors: yes
-
 - include: classic-hostagent-setup.yml
   when: is_certless_installer is undefined
 


### PR DESCRIPTION
Using failed as a jinja2 filter is deprecated as Ansible 2.5 (current latest
version is 2.9). It is noticed that using it as a filter is leading to failures
on certain setups. Move to using the new way of using failed as a test instead.

See more details here:
https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.5.html?highlight=failed#deprecated

Also, some minor cleanup/fixes.