### PR TITLE
Allow users to pass a log file location

### DIFF
--- a/pf9-express
+++ b/pf9-express
@@ -58,6 +58,7 @@ usage() {
   echo "-e|--extra-vars <string>   : ansible extra-vars <name=val,...>"
   echo "-b|--bypassPrereqs         : bypass pre-requisites"
   echo "-d|--deauth                : de-authorize host"
+  echo "-l|--log                   : Log output file. Assumes parent directory already exists."
   echo "-u|--upgradeK8s            : upgrade Kubernetes nodes"
   echo "-v|--inventory <file>      : use alternate inventory file for Ansible"
   echo "-f|--csvFile <file>        : import CSV file"
@@ -501,6 +502,11 @@ while [ $# -gt 0 ]; do
     ;;
   -d|--deauth)
     flag_deauth=1
+    ;;
+  -l|--log)
+    if [ $# -lt 2 ]; then usage; fi
+    install_log=${2}
+    shift
     ;;
   -u|--upgradeK8s)
     flag_k8s_upgrade=1


### PR DESCRIPTION
It would be convenient if users can optionally specify the log location of all
the Ansible tasks. The default continues to be the same previous behavior.

Tested running this on my local setup.