### PR TITLE
Move RedHat jinja2 filter to a test for Ansible 2.9+ compatibility

### DIFF
--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -17,4 +17,4 @@
 
 - name: Remount devpts mount point
   command: mount -o remount devpts
-  when: devpts_result|changed
+  when: devpts_result is changed


### PR DESCRIPTION
changed pipe for is

Ran against rhel host and successfully onboarded.