### PR TITLE
fixing an irritating install problem

### DIFF
--- a/roles/neutron-prerequisites/tasks/redhat.yml
+++ b/roles/neutron-prerequisites/tasks/redhat.yml
@@ -58,7 +58,6 @@
   yum:
     name: openvswitch
     state: present
-    disablerepo: '*'
     enablerepo: 'platform9-neutron-el7-repo,base'
 
 - name: Enable and start Open vSwitch


### PR DESCRIPTION
install fails at openvswitch install due to this one line.  Removing it installs it properly from the pf9 repo