### PR TITLE
Multipath-tools package task for Ubuntu hosts

### DIFF
--- a/roles/multipath/tasks/ubuntu.yml
+++ b/roles/multipath/tasks/ubuntu.yml
@@ -6,3 +6,8 @@
     - ansible_pkg_mgr == "apt"
 
 - debug: msg="running multipath/tasks/ubuntu.yml"
+
+- name: install multipath-tools
+  apt:
+    name: multipath-tools
+    state: present


### PR DESCRIPTION
Multipath-tools package for Ubuntu hosts wasn't being installed as part of the multipath role.  This is being fixed. 