### PR TITLE
Changed to install openstacksdk==0.39.0 in prereqs for python2 support

### DIFF
--- a/pf9-express
+++ b/pf9-express
@@ -397,7 +397,7 @@ install_prereqs() {
     fi
 
     ## install additional pip-based packages
-    for pkg in shade docker-py; do
+    for pkg in 'openstacksdk==0.39.0' docker-py; do
       echo -n "${pkg} "
       sudo pip install ${pkg} --ignore-installed > ${log} 2>&1
       if [ $? -ne 0 ]; then
@@ -449,7 +449,7 @@ install_prereqs() {
     fi
 
     ## install additional pip-based packages
-    for pkg in shade docker-py; do
+    for pkg in 'openstacksdk==0.39.0' docker-py; do
       echo -n "${pkg} "
       sudo pip install ${pkg} --ignore-installed > ${log} 2>&1
       if [ $? -ne 0 ]; then


### PR DESCRIPTION
pf9-express was failing for the machines running on python2 while obtaining the keystone token with the error - `openstacksdk is required for this module`.
Changed the pf9-express to install `openstacksdk 0.39.0` in prereqs as OpenStacksdk has dropped support for pip2. 

-  Edited pf9-express code to replace shade with 'openstacksdk==0.39.0' . 

one will have to uninstall all the existing openstacksdk versions using  - pip uninstall openstacksdk . This should be run multiple times to remove all the existing versions. 

pf9-express should be run without bypassing the pre-reqs to pick the new changes. 

