### PR TITLE
updated neutron prereqs role with the right repo so ovs version 2.11 will be pulled

### DIFF
--- a/roles/neutron-prerequisites/tasks/redhat.yml
+++ b/roles/neutron-prerequisites/tasks/redhat.yml
@@ -48,9 +48,11 @@
     enabled: no
   when: NetworkManager_install_status.stdout_lines is defined and NetworkManager_install_status.stdout_lines == "installed"
 
+
+
 - name: Add Platform9 Yum repository
   yum:
-    name: https://s3-us-west-1.amazonaws.com/platform9-neutron/noarch/platform9-neutron-repo-1-0.noarch.rpm
+    name: https://s3-us-west-1.amazonaws.com/platform9-neutron/noarch/platform9-neutron-repo.noarch.rpm
     state: present
     update_cache: yes
 
@@ -59,8 +61,7 @@
     name: openvswitch
     state: present
     disablerepo: '*'
-    enablerepo: 'platform9-neutron-el7-repo,base'
-
+    enablerepo: 'platform9-neutron-repo,base'
 - name: Enable and start Open vSwitch
   service:
     name: openvswitch

--- a/roles/neutron-prerequisites/tasks/ubuntu.yml
+++ b/roles/neutron-prerequisites/tasks/ubuntu.yml
@@ -17,7 +17,7 @@
 
 - name: Add Platform9 APT repository
   apt_repository:
-    repo: 'deb [trusted=yes] http://platform9-neutron.s3-website-us-west-1.amazonaws.com/ubuntu_latest /'
+    repo: 'deb http://platform9-neutron.s3-website-us-west-1.amazonaws.com/ubuntu_latest /'
     state: present
     update_cache: yes
 

--- a/roles/neutron-prerequisites/tasks/ubuntu.yml
+++ b/roles/neutron-prerequisites/tasks/ubuntu.yml
@@ -6,9 +6,18 @@
     - ifenslave
     - vlan
 
+- name: Download gpg key for Platform9 neutron repo
+  get_url:
+    url: https://platform9-neutron.s3-us-west-1.amazonaws.com/ubuntu_latest/key.gpg
+    dest: /tmp/pf9-key.gpg
+- name: Install Platform9 gpg key
+  apt_key: 
+    file: /tmp/pf9-key.gpg
+    state: present 
+
 - name: Add Platform9 APT repository
   apt_repository:
-    repo: 'deb [trusted=yes] http://platform9-neutron.s3-website-us-west-1.amazonaws.com ubuntu/'
+    repo: 'deb [trusted=yes] http://platform9-neutron.s3-website-us-west-1.amazonaws.com/ubuntu_latest /'
     state: present
     update_cache: yes
 
@@ -28,3 +37,5 @@
   apt:
     name: radvd
     state: present
+
+


### PR DESCRIPTION
**Summary** 

This change will ensure that ovs-version 2.11 is being installed on Ubuntu and Centos hosts as per the prerequisites for PMO 4.5 

I have tested this on  Ubuntu and Centos hosts. 
