### PR TITLE
Change Keystone endpoint from v2.0 -> v3

### DIFF
--- a/roles/pf9-auth/tasks/main.yml
+++ b/roles/pf9-auth/tasks/main.yml
@@ -15,10 +15,12 @@
 - name: Set OS_AUTH fact
   set_fact:
     os_auth:
-      auth_url: "{{du_url}}/keystone/v2.0"
+      auth_url: "{{du_url}}/keystone/v3"
       username: "{{os_username}}"
       password: "{{os_password}}"
       project_name: "{{os_tenant}}"
+      user_domain_name: "default"
+      project_domain_name: "default"
 
 - name: Obtain authentication token from Keystone (with custom python)
   os_auth:


### PR DESCRIPTION
Starting with the Platform9 5.0 release, the v2.0 Keystone endpoint will be removed. This change should still be compatible with Platform9 environments < 5.0 as well.