### PR TITLE
Update cinder config template

### DIFF
--- a/roles/map-role/tasks/main.yml
+++ b/roles/map-role/tasks/main.yml
@@ -58,12 +58,12 @@
 # Cinder Settings
 ################################################################################
 - block:
-  # cinder_iscsi_ip_address
+  # cinder_target_ip_address
   - set_fact:
       cinder_ip: "{{ansible_host}}"
     when: cinder_ip is undefined
   - set_fact:
-      cinder_iscsi_ip_address: "{{cinder_ip}}"
+      cinder_target_ip_address: "{{cinder_ip}}"
 
   # cinder_volume_backend_name
   - set_fact:

--- a/roles/map-role/templates/pf9-cindervolume-lvm.j2
+++ b/roles/map-role/templates/pf9-cindervolume-lvm.j2
@@ -1,5 +1,5 @@
 {
-    "iscsi_ip_address": "{{cinder_iscsi_ip_address}}",
+    "target_ip_address": "{{cinder_target_ip_address}}",
     "volume_backend_name": "{{cinder_backend_name}}",
     "volume_driver": "{{cinder_volume_driver}}"
 }


### PR DESCRIPTION
The iscsi_ip_address option in Cinder was updated to target_ip_address.
https://docs.openstack.org/cinder/train/configuration/block-storage/samples/cinder.conf.html 

This change was tested in the SE lab. 