### PR TITLE
Add changes to cluster upgrade playbook to work with multi-version and proxy

### DIFF
--- a/pf9-k8s-upgrade.yml
+++ b/pf9-k8s-upgrade.yml
@@ -16,5 +16,8 @@
   roles:
     - pf9-auth
     - k8s-node-drain
-    - { role: "map-role", rolename: "pf9-kube" }
+    - { role: "map-role", rolename: "pf9-kube", version: "1.18.10-pmk.1547" }
     - { role: "wait-for-convergence" }
+  environment:
+    http_proxy: #<there-proxy-server>
+    no_proxy: #<k8s-api-server-vip/fqdn>

--- a/pf9-k8s-upgrade.yml
+++ b/pf9-k8s-upgrade.yml
@@ -23,5 +23,5 @@
     - { role: "map-role", rolename: "pf9-kube"}
     - { role: "wait-for-convergence" }
   environment:
-    http_proxy: proxy_url
-    no_proxy: no_proxy_urls
+    http_proxy: "{{ proxy_url }}"
+    no_proxy: "{{ no_proxy_urls }}"

--- a/pf9-k8s-upgrade.yml
+++ b/pf9-k8s-upgrade.yml
@@ -11,13 +11,17 @@
 
 - hosts:
     - k8s_worker
+  vars:
+    roleversion: "" # provide appropriate pf9-kube role version, e.g. 1.18.10-pmk.1547
+    proxy_url: "" # provide proxy URL if running in such environment
+    no_proxy_urls: "" # If running in proxy environment, provide API server VIP/FQDN
   become: true
   serial: 15
   roles:
     - pf9-auth
     - k8s-node-drain
-    - { role: "map-role", rolename: "pf9-kube", version: "1.18.10-pmk.1547" }
+    - { role: "map-role", rolename: "pf9-kube"}
     - { role: "wait-for-convergence" }
   environment:
-    http_proxy: #<there-proxy-server>
-    no_proxy: #<k8s-api-server-vip/fqdn>
+    http_proxy: proxy_url
+    no_proxy: no_proxy_urls

--- a/roles/map-role/tasks/main.yml
+++ b/roles/map-role/tasks/main.yml
@@ -132,9 +132,9 @@
   shell: "cat /tmp/keystone-token.txt"
   register: api_token
 
-- name: "Assigning Role - {{rolename}}"
+- name: "Assigning Role - {{rolename}} with role version"
   uri:
-    url: "https://{{du_fqdn}}/resmgr/v1/hosts/{{host_id.stdout.strip()}}/roles/{{rolename}}/versions/{{version}}"
+    url: "https://{{du_fqdn}}/resmgr/v1/hosts/{{host_id.stdout.strip()}}/roles/{{rolename}}/versions/{{roleversion}}"
     method: PUT
     body: "{{role_json.stdout.strip()}}"
     body_format: json
@@ -144,5 +144,19 @@
       X-Auth-Token: "{{api_token.stdout.strip()}}"
   register: uri_result
   delegate_to: localhost
+  when: roleversion is defined and roleversion != ""
+- name: "Assigning Role - {{rolename}}"
+  uri:
+    url: "https://{{du_fqdn}}/resmgr/v1/hosts/{{host_id.stdout.strip()}}/roles/{{rolename}}"
+    method: PUT
+    body: "{{role_json.stdout.strip()}}"
+    body_format: json
+    validate_certs: False
+    headers:
+      Content-Type: "application/json"
+      X-Auth-Token: "{{api_token.stdout.strip()}}"
+  register: uri_result
+  delegate_to: localhost
+  when: not (roleversion is defined) or roleversion == ""
 - debug: var=uri_result
 

--- a/roles/map-role/tasks/main.yml
+++ b/roles/map-role/tasks/main.yml
@@ -134,7 +134,7 @@
 
 - name: "Assigning Role - {{rolename}}"
   uri:
-    url: "https://{{du_fqdn}}/resmgr/v1/hosts/{{host_id.stdout.strip()}}/roles/{{rolename}}"
+    url: "https://{{du_fqdn}}/resmgr/v1/hosts/{{host_id.stdout.strip()}}/roles/{{rolename}}/versions/{{version}}"
     method: PUT
     body: "{{role_json.stdout.strip()}}"
     body_format: json

--- a/roles/wait-for-convergence/tasks/main.yml
+++ b/roles/wait-for-convergence/tasks/main.yml
@@ -19,7 +19,7 @@
 - debug: msg="running wait_for_agent_convergence.sh {{du_fqdn}} {{host_id.stdout.strip()}} {{du_username}} ******** <{{flags}}>"
 
 - name: wait for pf9-hostagent to converge
-  script: "files/wait_for_agent_convergence.sh {{du_fqdn}} {{host_id.stdout.strip()}} {{du_username}} \'{{du_password}}\' {{flags}}"
+  script: "files/wait_for_agent_convergence.sh {{du_fqdn}} {{host_id.stdout.strip()}} {{du_username}} '{{du_password}}' {{flags}}"
   register: waitfor_agent
 
 - debug: var=waitfor_agent


### PR DESCRIPTION
1. Update k8s upgrade playbook to expect proxy environment and pf9-kube role version
2. Updated map-role to expect pf9-kube role version as the nodes in a
   cluster need to converge to a specific version of pf9-kube