### PR TITLE
added host group guard to cinder pre-flight checks

### DIFF
--- a/roles/pre-flight-checks-openstack/tasks/main.yml
+++ b/roles/pre-flight-checks-openstack/tasks/main.yml
@@ -101,8 +101,10 @@
   stat:
     path: "{{cinder_image_conversion_cache}}"
   register: cinder_image_conversion_cache_dir_exists
+  when: inventory_hostname in groups['cinder']
 
 - debug: var=cinder_image_conversion_cache_dir_exists
+  when: inventory_hostname in groups['cinder']
 
 - block:
   - debug: msg="Validate minimum free space for cinder_image_conversion_cache (at least {{cinder_image_cache_min_free_space}} KBytes)"


### PR DESCRIPTION
Fixes following error when groups `[cinder]` is not used in inventory file
```
TASK [pre-flight-checks-openstack : check if {{cinder_image_conversion_cache}} directory exists] ****************************************
Friday 28 July 2023  10:47:55 +0000 (0:00:00.043)       0:00:15.304 ***********
fatal: [sn-u3]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'cinder_image_conversion_cache' is undefined\n\nThe error appears to be in '/root/express.latest/roles/pre-flight-checks-openstack/tasks/main.yml': line 100, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"check if {{cinder_image_conversion_cache}} directory exists\"\n  ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes. Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}```