### PR TITLE
Private/snimje08072023

### DIFF
--- a/roles/secure-live-migration/tasks/main.yaml
+++ b/roles/secure-live-migration/tasks/main.yaml
@@ -3,3 +3,5 @@
 - include: configure.yaml
 - include: services.yaml
 - include: passwordless-ssh.yaml
+- include: ubuntu.yml
+  when: (ansible_distribution == "Ubuntu") and (ansible_distribution_major_version == '20')

--- a/roles/secure-live-migration/tasks/main.yaml
+++ b/roles/secure-live-migration/tasks/main.yaml
@@ -3,5 +3,5 @@
 - include: configure.yaml
 - include: services.yaml
 - include: passwordless-ssh.yaml
-- include: ubuntu.yml
+- include: ubuntu.yaml
   when: (ansible_distribution == "Ubuntu") and (ansible_distribution_major_version == '20')

--- a/roles/secure-live-migration/tasks/ubuntu.yaml
+++ b/roles/secure-live-migration/tasks/ubuntu.yaml
@@ -1,0 +1,5 @@
+- name: Enable service httpd and ensure it is not masked
+  ansible.builtin.systemd:
+    name: libvirtd-tls.socket
+    enabled: true
+    masked: no

--- a/roles/secure-live-migration/tasks/ubuntu.yaml
+++ b/roles/secure-live-migration/tasks/ubuntu.yaml
@@ -1,4 +1,4 @@
-- name: Enable service httpd and ensure it is not masked
+- name: Enable service libvirtd-tls.socket and ensure it is not masked
   ansible.builtin.systemd:
     name: libvirtd-tls.socket
     enabled: true


### PR DESCRIPTION
verified

```

[root@sn-u1:~# systemctl list-unit-files |grep libvirt
libvirt-guests.service                     enabled         enabled
libvirtd.service                           enabled         enabled
libvirtd-admin.socket                      enabled         enabled
libvirtd-ro.socket                         enabled         enabled
libvirtd-tcp.socket                        disabled        enabled
libvirtd-tls.socket                        disabled        enabled
libvirtd.socket                            enabled         enabled
root@sn-u1:~# tail -f  /var/log/pf9/hostagent.log
2023-08-07 04:34:12,761 - session.py INFO - Already converged. Idling...
2023-08-07 04:34:17,393 - session.py INFO - Already converged. Idling...
2023-08-07 04:34:22,082 - session.py INFO - Already converged. Idling...
2023-08-07 04:34:26,788 - session.py INFO - Already converged. Idling...
2023-08-07 04:34:48,619 - session.py INFO - Already converged. Idling...
2023-08-07 04:35:53,167 - session.py INFO - Already converged. Idling...
2023-08-07 04:36:57,580 - session.py INFO - Already converged. Idling...
2023-08-07 04:38:02,320 - session.py INFO - Already converged. Idling...
2023-08-07 04:39:06,686 - session.py INFO - Already converged. Idling...
2023-08-07 04:40:11,543 - session.py INFO - Already converged. Idling...
2023-08-07 04:41:16,176 - session.py INFO - Already converged. Idling...

^C
root@sn-u1:~# systemctl list-unit-files |grep libvirt
libvirt-guests.service                     enabled         enabled
libvirtd.service                           enabled         enabled
libvirtd-admin.socket                      enabled         enabled
libvirtd-ro.socket                         enabled         enabled
libvirtd-tcp.socket                        disabled        enabled
libvirtd-tls.socket                        enabled         enabled
libvirtd.socket                            enabled         enabled


```