### PR TITLE
Private/snimje/cs 1352

### DIFF
--- a/pf9-express.yml
+++ b/pf9-express.yml
@@ -125,13 +125,9 @@
 # Openstack Image Nodes
 - hosts: glance
   become: true
-  tasks:
-    - name: validate pf9/host_id.conf
-      stat:
-        path: /etc/pf9/host_id.conf
-      register: stat_hostid
   roles:
-    - { role: "pf9-hostagent", when: stat_hostid.stat.exists == false }
+    - common  
+    - pf9-hostagent
     - { role: "glance-host", when: autoreg == "on" }
     - { role: "map-role", rolename: "pf9-glance-role", when: autoreg == "on" }
     - { role: "wait-for-convergence", when: autoreg == "on" }
@@ -140,6 +136,8 @@
 - hosts: cinder
   become: true
   roles:
+    - common  
+    - pf9-hostagent
     - { role: "lvm", when: autoreg == "on" }
     - { role: "map-role", rolename: "pf9-cindervolume-base", when: autoreg == "on" }
     - { role: "map-role", rolename: "pf9-cindervolume-lvm", when: autoreg == "on" }
@@ -149,6 +147,8 @@
 - hosts: designate
   become: true
   roles:
+    - common
+    - pf9-hostagent  
     - { role: "map-role", rolename: "pf9-designate", when: autoreg == "on" }
     - { role: "wait-for-convergence", when: autoreg == "on" }
 

--- a/pf9-express.yml
+++ b/pf9-express.yml
@@ -125,7 +125,13 @@
 # Openstack Image Nodes
 - hosts: glance
   become: true
+  tasks:
+    - name: validate pf9/host_id.conf
+      stat:
+        path: /etc/pf9/host_id.conf
+      register: stat_hostid
   roles:
+    - { role: "pf9-hostagent", when: stat_hostid.stat.exists == false }
     - { role: "glance-host", when: autoreg == "on" }
     - { role: "map-role", rolename: "pf9-glance-role", when: autoreg == "on" }
     - { role: "wait-for-convergence", when: autoreg == "on" }


### PR DESCRIPTION

Task: [cs-1352](https://platform9.atlassian.net/browse/CS-1352)

verified as follows:
deployed glance role only (attaching the log for reference)
deployed cinder role only
deployed glance role after cinder role
verified by creating a boot volume of the type cinder - volume pulled the image from glance endpoint successfully
deployed hypervisor role at the end
all tests passed.

Note:
adding the common role was not mandatory but added it as a best practice in order to maintain parity with other roles.
pf9-hostagent role has counter measures to skip host-agent installation when one is already present on the host.