### PR TITLE
Update ansible.cfg with `timeout` parameter.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,6 +11,7 @@ deprecation_warnings=False
 retry_files_enabled = False
 command_warnings = False
 callback_whitelist = profile_roles
+timeout=60
 
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
Sometimes the task execution fails with below error because the default timeout value for connection plugin is 10s.

`FAILED! => { "msg": "Timeout (12s) waiting for privilege escalation prompt: " }`

This patch is to increase the `timeout` value to 60s in the working directory's `ansible.cfg` that solves the issue.