### PR TITLE
Private/snimje/cs 1675 - NM support in Rocky9, Libvirtd restart in Rocky9, 8, Ubuntu 20.04, 22.04 handler update

### DIFF
--- a/roles/neutron-prerequisites/tasks/main.yml
+++ b/roles/neutron-prerequisites/tasks/main.yml
@@ -15,7 +15,10 @@
   when: '"RedHat" in ansible_distribution or ansible_distribution == "CentOS"'
 
 - include: rocky.yml
-  when: ansible_distribution == "Rocky"
+  when: ansible_distribution == "Rocky" and ansible_distribution_major_version == "8"
+
+- include: rocky9.yml
+  when: ansible_distribution == "Rocky" and ansible_distribution_major_version == "9"
 
 - include: ubuntu.yml
   when: ansible_distribution == "Ubuntu"

--- a/roles/neutron-prerequisites/tasks/rocky9.yml
+++ b/roles/neutron-prerequisites/tasks/rocky9.yml
@@ -1,0 +1,49 @@
+---
+- name: Set SELinux to permissive
+  selinux:
+    policy: targeted
+    state: permissive
+
+- name: Check if firewalld is a service
+  shell: "systemctl list-units | grep firewalld.service > /dev/null 2>&1; if [ $? -eq 0 ]; then echo 'installed'; fi"
+  register: firewalld_service_install_status
+
+- name: Disable firewalld
+  service:
+    state: stopped
+    name: firewalld
+    enabled: no
+  when: firewalld_service_install_status.stdout is defined and firewalld_service_install_status.stdout.strip() == "installed"
+
+- name: Installing iptables-services
+  dnf:
+    name: iptables-services
+    state: present
+
+- name: Add OpenStack DNF repository
+  dnf:
+    name: centos-release-openstack-yoga.noarch
+    state: present
+    disable_gpg_check: yes
+    update_cache: yes
+
+- name: Install Open vSwitch
+  dnf:
+    name: openvswitch3.1.x86_64
+    state: present
+
+- name: Install Open vSwitch scripts
+  dnf:
+    name: openstack-network-scripts-openvswitch3.1.x86_64
+    state: present
+
+- name: Enable and start Open vSwitch
+  service:
+    name: openvswitch
+    state: started
+    enabled: yes
+
+- name: Install Router Advertisement Daemon
+  dnf:
+    name: radvd
+    state: present

--- a/roles/secure-live-migration/handlers/main.yaml
+++ b/roles/secure-live-migration/handlers/main.yaml
@@ -3,6 +3,46 @@
   service:
     name: "{{ libvirtd_service_name }}"
     state: restarted
+    when: 
+      - ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "18"
+      - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "7"
+
+- listen: restart libvirtd-systemd-socket
+  name: Stop libvirtd service
+  ansible.builtin.systemd:
+    name: "{{ libvirtd_service_name }}"
+    state: stopped
+    when: 
+      - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
+      - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")   
+
+- listen: restart libvirtd-systemd-socket
+  name: Start libvirtd-tls.socket and set enabled
+  ansible.builtin.systemd:
+    name: libvirtd-tls.socket
+    state: restarted
+    enabled: yes
+    when: 
+      - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
+      - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")     
+
+- listen: restart libvirtd-systemd-socket
+  name: Restart libvirtd.socket
+  ansible.builtin.systemd:
+    name: libvirtd.socket
+    state: restarted
+    when: 
+      - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
+      - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")    
+
+- listen: restart libvirtd-systemd-socket
+  name: Start libvirtd service
+  ansible.builtin.systemd:
+    name: "{{ libvirtd_service_name }}"
+    state: started
+    when: 
+      - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
+      - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")
 
 - name: restart pf9-ostackhost
   service:

--- a/roles/secure-live-migration/handlers/main.yaml
+++ b/roles/secure-live-migration/handlers/main.yaml
@@ -1,20 +1,21 @@
 ---
-- name: restart libvirtd
-  service:
+- listen: restart libvirtd
+  name: Restart libvirtd service
+  ansible.builtin.service:
     name: "{{ libvirtd_service_name }}"
     state: restarted
-    when: 
-      - ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "18"
-      - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "7"
+  when: 
+    - ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "18"
+    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version == "7")
 
 - listen: restart libvirtd-systemd-socket
   name: Stop libvirtd service
   ansible.builtin.systemd:
     name: "{{ libvirtd_service_name }}"
     state: stopped
-    when: 
-      - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
-      - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")   
+  when: 
+    - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
+    - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")   
 
 - listen: restart libvirtd-systemd-socket
   name: Start libvirtd-tls.socket and set enabled
@@ -22,29 +23,29 @@
     name: libvirtd-tls.socket
     state: restarted
     enabled: yes
-    when: 
-      - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
-      - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")     
+  when: 
+    - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
+    - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")     
 
 - listen: restart libvirtd-systemd-socket
   name: Restart libvirtd.socket
   ansible.builtin.systemd:
     name: libvirtd.socket
     state: restarted
-    when: 
-      - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
-      - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")    
+  when: 
+    - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
+    - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")    
 
 - listen: restart libvirtd-systemd-socket
   name: Start libvirtd service
   ansible.builtin.systemd:
     name: "{{ libvirtd_service_name }}"
     state: started
-    when: 
-      - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
-      - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")
+  when: 
+    - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
+    - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")
 
 - name: restart pf9-ostackhost
-  service:
+  ansible.builtin.service:
     name: pf9-ostackhost
     state: restarted

--- a/roles/secure-live-migration/handlers/main.yaml
+++ b/roles/secure-live-migration/handlers/main.yaml
@@ -5,8 +5,7 @@
     name: "{{ libvirtd_service_name }}"
     state: restarted
   when: 
-    - ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "18"
-    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version == "7")
+    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "18") or ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version == "7"))
 
 - listen: restart libvirtd-systemd-socket
   name: Stop libvirtd service
@@ -14,8 +13,8 @@
     name: "{{ libvirtd_service_name }}"
     state: stopped
   when: 
-    - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
-    - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")   
+    - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky" or ansible_distribution == "Ubuntu")
+    - (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9" or ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22") 
 
 - listen: restart libvirtd-systemd-socket
   name: Start libvirtd-tls.socket and set enabled
@@ -24,8 +23,8 @@
     state: restarted
     enabled: yes
   when: 
-    - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
-    - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")     
+    - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky" or ansible_distribution == "Ubuntu")
+    - (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9" or ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22") 
 
 - listen: restart libvirtd-systemd-socket
   name: Restart libvirtd.socket
@@ -33,8 +32,8 @@
     name: libvirtd.socket
     state: restarted
   when: 
-    - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
-    - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")    
+    - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky" or ansible_distribution == "Ubuntu")
+    - (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9" or ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22") 
 
 - listen: restart libvirtd-systemd-socket
   name: Start libvirtd service
@@ -42,8 +41,8 @@
     name: "{{ libvirtd_service_name }}"
     state: started
   when: 
-    - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky") and (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9")
-    - ansible_distribution == "Ubuntu" and (ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")
+    - (ansible_distribution == "RedHat" or ansible_distribution == "Rocky" or ansible_distribution == "Ubuntu")
+    - (ansible_distribution_major_version == "8" or ansible_distribution_major_version == "9" or ansible_distribution_major_version == "20" or ansible_distribution_major_version == "22")   
 
 - name: restart pf9-ostackhost
   ansible.builtin.service:

--- a/roles/secure-live-migration/tasks/configure.yaml
+++ b/roles/secure-live-migration/tasks/configure.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Tell libvirt to listen on startup - Red Hat
+- name: Tell libvirt to listen on startup - RHEL 7 or CentOS 7
   lineinfile:
     state: present
     create: True
@@ -11,7 +11,7 @@
   when: (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "7"
   notify: restart libvirtd
 
-- name: Tell libvirt to listen on startup - Ubuntu
+- name: Tell libvirt to listen on startup - Ubuntu 18.04
   lineinfile:
     state: present
     create: True

--- a/roles/secure-live-migration/tasks/configure.yaml
+++ b/roles/secure-live-migration/tasks/configure.yaml
@@ -68,8 +68,7 @@
     key_file: "\"{{ libvirt_pki_path }}/clientkey.pem\""
   notify: 
     - restart libvirtd
-    - restart libvirtd-ubuntu
-    - restart libvirtd-rocky
+    - restart libvirtd-systemd-socket
 
 - name: Set libvirt live migration settings in Nova.conf
   ini_file:

--- a/roles/secure-live-migration/tasks/configure.yaml
+++ b/roles/secure-live-migration/tasks/configure.yaml
@@ -8,7 +8,7 @@
     regexp: '^#?LIBVIRTD_ARGS.*$'
   tags: 
     - live-migration
-  when: '"RedHat" in ansible_distribution or ansible_distribution == "CentOS"'
+  when: (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "7"
   notify: restart libvirtd
 
 - name: Tell libvirt to listen on startup - Ubuntu
@@ -20,7 +20,7 @@
     regexp: '^#?libvirtd_opts=*.*$'
   tags: 
     - live-migration
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "18"
   notify: restart libvirtd
 
 - name: "Create {{ libvirt_pki_path }}"
@@ -66,7 +66,10 @@
     ca_file: "\"{{ libvirt_pki_path }}/cacert.pem\""
     cert_file: "\"{{ libvirt_pki_path }}/clientcert.pem\""
     key_file: "\"{{ libvirt_pki_path }}/clientkey.pem\""
-  notify: restart libvirtd
+  notify: 
+    - restart libvirtd
+    - restart libvirtd-ubuntu
+    - restart libvirtd-rocky
 
 - name: Set libvirt live migration settings in Nova.conf
   ini_file:

--- a/roles/secure-live-migration/tasks/main.yaml
+++ b/roles/secure-live-migration/tasks/main.yaml
@@ -4,4 +4,4 @@
 - include: services.yaml
 - include: passwordless-ssh.yaml
 - include: ubuntu.yaml
-  when: (ansible_distribution == "Ubuntu") and (ansible_distribution_major_version == '20')
+  when: (ansible_distribution == "Ubuntu") and (ansible_distribution_major_version == '20') and (ansible_distribution_major_version == '22')


### PR DESCRIPTION
[1] Removes the play for disabling NetworkManager in Rocky9. Rocky9 with NM enabled hypervisor will be supported with this PR merged.
- Tested with NetworkManager enabled, keyfiles to manage Network interfaces. Removed init script plugin from NM.
[2] Enhanced Secure Live migration role:
- Libvirtd systemd service is restarted with TLS socket in U22.04, 20.04, Rocky and RHEL 8 and 9.
Attaching log from rocky9 host.
[pf9-express.2024-10-17_02:04:49.log](https://github.com/user-attachments/files/17415564/pf9-express.2024-10-17_02.04.49.log)

